### PR TITLE
Fix: Remove handlers after multiprocessing

### DIFF
--- a/multiprocessing_logging/console.py
+++ b/multiprocessing_logging/console.py
@@ -8,11 +8,12 @@ import time
 def do_job(task):
     random_int = randrange(10)
     time.sleep(random_int)
-    logging.info('do_job called with: {} => {}'.format(task, datetime.now()))
+    logging.info('func called with task: {}'.format(task))
     return random_int
 
 
 def main():
+    # setup logger
     test_logger = logging.basicConfig(
         level=logging.DEBUG,
         format='%(levelname)s: %(asctime)s - %(process)s - %(message)s')
@@ -25,19 +26,17 @@ def main():
     # to get the maximum speed for I/O tasks.
     processes = 100
 
-    test_logger = logging.getLogger(logger_name)
     test_logger.info('Hi, I\'m the main thread')
 
     pool = PoolWithLogging(processes=processes,
                            logger_name=logger_name)
-
     start_time = time.time()
     return_values = pool.map(do_job, tasks)
     end_time = time.time()
-
     pool.close()
 
-    test_logger.info('Hi, from the main thread again')
+    test_logger.info('Hi, from the main thread again.')
+
     print('*** Handling all tasks took {} seconds ***'.format(
         end_time - start_time))
 

--- a/multiprocessing_logging/pool_with_logging.py
+++ b/multiprocessing_logging/pool_with_logging.py
@@ -17,7 +17,6 @@ else:
 
 class PoolWithLogging(Pool):
     """Custom multiprocessing Pool logging using the defined logger
-
     This class is though as an extension of 'multiprocessing.Pool' to be able
     to use the logger in the worker function of doing multiprocessing.
     """
@@ -26,34 +25,47 @@ class PoolWithLogging(Pool):
         if not logger_name:
             logger_name = __name__
         self.logger_name = logger_name
-        self.mp_queue_listener, self.mp_queue = self.logger_init()
-        initargs = tuple([self.mp_queue])
-        initializer = self.worker_init(self.mp_queue)
+        self.queue_handler = None
+        self.stream_handler = None
+
+        # start queue_listener
+        self.mp_queue_listener, mp_queue = self.logger_init()
+
+        # prepare and call original Pool init
+        initargs = tuple([mp_queue])
+        initializer = self.add_queue_handler(mp_queue)
         super(PoolWithLogging, self).__init__(processes=processes,
                                               initializer=initializer,
                                               initargs=initargs)
 
     def close(self):
+        # close pool
         super(PoolWithLogging, self).close()
+        # stop queue listener
         self.mp_queue_listener.stop()
-
-    def worker_init(self, mp_queque):
-        # all records from worker processes go to qh and then into q
-        qh = QueueHandler(mp_queque)
+        # remove previously added stream handler
         logger = logging.getLogger(self.logger_name)
-        logger.addHandler(qh)
+        logger.removeHandler(self.stream_handler)
+        logger.removeHandler(self.queue_handler)
+
+    def add_queue_handler(self, mp_queque):
+        # all records from worker processes go to
+        # queue_handler and then into mp_queue.
+        self.queue_handler = QueueHandler(mp_queque)
+        # add queue_handler to logger
+        logger = logging.getLogger(self.logger_name)
+        logger.addHandler(self.queue_handler)
 
     def logger_init(self):
         mp_queue = multiprocessing.Queue()
         # this is the handler for all log records
-        handler = logging.StreamHandler()
-
-        # ql gets records from the queue and sends them to the handler
-        mp_queue_listener = QueueListener(mp_queue, handler)
+        self.stream_handler = logging.StreamHandler()
+        # queue_listener gets records from the queue
+        # and sends them to the handler.
+        mp_queue_listener = QueueListener(mp_queue, self.stream_handler)
         mp_queue_listener.start()
-
+        # add stream_handler to logger
         logger = logging.getLogger(self.logger_name)
-        # add handler to logger so records from this process are handled
-        logger.addHandler(handler)
+        logger.addHandler(self.stream_handler)
 
         return mp_queue_listener, mp_queue


### PR DESCRIPTION
Because after multiprocessing there were to prints of the log I removed the handlers which are appended. This resets the logger to the previous state.